### PR TITLE
Added delay calculation

### DIFF
--- a/pkg/systems/spawnSystem/spawnSystem.src
+++ b/pkg/systems/spawnSystem/spawnSystem.src
@@ -91,6 +91,8 @@ function CalcNextTick()
 
 		SleepMS(10);
 	endforeach
+	
+	delay_time := delay_time - Polcore().systime;
 
 	if( delay_time <= 0 )
 		delay_time := 60;


### PR DESCRIPTION
added a calculation that calculates actual delay_time which is then passed onto to the continuous while loop, which in turn is eventually used to trigger the SpawntheRegions() function.

old situation actually passed a time, instead of a delay.